### PR TITLE
Feature/update to htof 0.2.9

### DIFF
--- a/orbit3d/main.py
+++ b/orbit3d/main.py
@@ -70,7 +70,7 @@ def initialize_data(config):
 
     data = orbit.Data(HipID, RVFile, AstrometryFile)
     if use_epoch_astrometry:
-        to_jd = lambda x: Time(x, format='decimalyear').jd +.5
+        to_jd = lambda x: Time(x, format='decimalyear').jd
         Gaia_fitter = Astrometry('GaiaDR2', '%06d' % (HipID), GaiaDataDir,
                                  central_epoch_ra=to_jd(data.epRA_G),
                                  central_epoch_dec=to_jd(data.epDec_G),

--- a/orbit3d/main.py
+++ b/orbit3d/main.py
@@ -87,17 +87,6 @@ def initialize_data(config):
         hip1_fast_fitter = orbit.AstrometricFitter(Hip1_fitter)
         hip2_fast_fitter = orbit.AstrometricFitter(Hip2_fitter)
         gaia_fast_fitter = orbit.AstrometricFitter(Gaia_fitter)
-        for fitter in [Hip1_fitter, Hip2_fitter, Gaia_fitter]:
-            print(fitter.fitter._chi2_matrix)
-            print(fitter.fitter.astrometric_solution_vector_components['ra'].T.copy(order='C'))
-            print(fitter.fitter.astrometric_solution_vector_components['dec'].T.copy(order='C'))
-            print(fitter.fitter.astrometric_solution_vector_components['ra'].shape[0])
-            print(fitter.fitter.astrometric_solution_vector_components['ra'].shape[1])
-            print(fitter.fitter.central_epoch_ra)
-            print(data.epRA_H)
-            print(fitter.fitter.central_epoch_dec)
-            print(fitter.fitter.epoch_times - fitter.fitter.central_epoch_ra)
-            #print(fitter.data.julian_day_epoch())
 
         data = orbit.Data(HipID, RVFile, AstrometryFile, use_epoch_astrometry,
                           epochs_Hip1=Hip1_fitter.data.julian_day_epoch(),

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,6 @@ setup(name='orbit3d',
       python_requires='>=3.5',
       package_dir={'orbit3d': 'orbit3d'},
       package_data={'orbit3d': ['data/*.fits']},
-      install_requires=['numpy>=1.13', 'htof>=0.2.5', 'emcee',
+      install_requires=['numpy>=1.13', 'htof>=0.2.9', 'emcee',
                         'Cython', 'pandas', 'astropy', 'pytest'],
       entry_points={'console_scripts': ['fit_orbit=orbit3d.main:run']})

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,6 @@ setup(name='orbit3d',
       python_requires='>=3.5',
       package_dir={'orbit3d': 'orbit3d'},
       package_data={'orbit3d': ['data/*.fits']},
-      install_requires=['numpy>=1.13', 'htof==0.1.3', 'emcee',
+      install_requires=['numpy>=1.13', 'htof==0.2.3', 'emcee',
                         'Cython', 'pandas', 'astropy', 'pytest'],
       entry_points={'console_scripts': ['fit_orbit=orbit3d.main:run']})

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,6 @@ setup(name='orbit3d',
       python_requires='>=3.5',
       package_dir={'orbit3d': 'orbit3d'},
       package_data={'orbit3d': ['data/*.fits']},
-      install_requires=['numpy>=1.13', 'htof==0.2.3', 'emcee',
+      install_requires=['numpy>=1.13', 'htof>=0.2.5', 'emcee',
                         'Cython', 'pandas', 'astropy', 'pytest'],
       entry_points={'console_scripts': ['fit_orbit=orbit3d.main:run']})


### PR DESCRIPTION
This PR updates the syntax in orbit3d that calls HTOF so that it can use the newer versions (0.2.0 and above) of HTOF. The min version of HTOF has been pinned to >=0.2.9 (the most up to date version of HTOF).